### PR TITLE
[semver:patch] fix: add circleci runner node to jest cache

### DIFF
--- a/src/commands/restore-cache.yml
+++ b/src/commands/restore-cache.yml
@@ -9,7 +9,7 @@ steps:
   - restore_cache:
       name: Restoring jest cache
       keys:
-        - jest-cache-{{ checksum "/tmp/jest-cache-previous-commit-hash.txt" }}
+        - jest-cache-{{ .Environment.CIRCLE_NODE_INDEX }}-{{ checksum "/tmp/jest-cache-previous-commit-hash.txt" }}
   - run:
       name: Copy jest cache to remote docker (if necessary)
       command: |

--- a/src/commands/save-cache.yml
+++ b/src/commands/save-cache.yml
@@ -8,7 +8,7 @@ parameters:
 steps:
   - save_cache:
       name: Save jest cache
-      key: jest-cache-{{ checksum "/tmp/jest-cache-current-commit-hash.txt" }}
+      key: jest-cache-{{ .Environment.CIRCLE_NODE_INDEX }}-{{ checksum "/tmp/jest-cache-current-commit-hash.txt" }}
       paths:
         - <<parameters.jest-cache-location>>
       when: always


### PR DESCRIPTION
Previously, the Jest cache key didn't account for people using [CircleCI's parallelism feature](https://circleci.com/docs/parallelism-faster-jobs). The first parallel job to finish would "win" at producing the cache.

With this change, the `CIRCLE_NODE_INDEX` is included in the cache key. This is a number representing the runner node number ([docs](https://circleci.com/docs/variable)):

![Screen Shot 2022-09-29 at 13 56 26](https://user-images.githubusercontent.com/630449/193129625-cfed8acc-5a1e-4e0b-9cd6-c255e190b8b8.png)